### PR TITLE
Fix RelTrait conversion (e.g. distribution, collation), added test ca…

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/RelTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/plan/RelTraitDef.java
@@ -183,14 +183,13 @@ public abstract class RelTraitDef<T extends RelTrait> {
    * @param fromTrait the RelTrait to convert from
    * @param toTrait   the RelTrait to convert to
    * @param fromRel   the RelNode to convert from (with fromTrait)
-   * @param toRel     the RelNode to convert to (with toTrait)
    * @return true if fromTrait can be converted to toTrait
    */
   public boolean canConvert(
-          RelOptPlanner planner,
-          T fromTrait,
-          T toTrait,
-          RelNode fromRel) {
+      RelOptPlanner planner,
+      T fromTrait,
+      T toTrait,
+      RelNode fromRel) {
     return canConvert(planner, fromTrait, toTrait);
   }
 

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSet.java
@@ -149,6 +149,72 @@ class RelSet {
     return subset;
   }
 
+  private void addAbstractConverters(
+      VolcanoPlanner planner, RelOptCluster cluster, RelSubset subset, boolean subsetToOthers) {
+    // Converters from newly introduced subset to all the remaining one (vice versa), only if
+    // we can convert.  No point adding converters if it is not possible.
+    for (RelSubset other : subsets) {
+      if (other == subset) {
+        continue;
+      }
+
+      assert other.getTraitSet().size() == subset.getTraitSet().size();
+
+      final ImmutableList<RelTrait> otherTrait =
+              subset.getTraitSet().difference(other.getTraitSet());
+      boolean addAbstractConverter = true;
+      int numTraitNeedConvert = 0;
+
+      for (RelTrait curOtherTrait : otherTrait) {
+        RelTraitDef traitDef = curOtherTrait.getTraitDef();
+        RelTrait curRelTrait = subset.getTraitSet().getTrait(traitDef);
+
+        assert curRelTrait.getTraitDef() == traitDef;
+
+        if (curRelTrait == null) {
+          addAbstractConverter = false;
+          break;
+        }
+
+        boolean canConvert = false;
+        boolean needConvert = false;
+        if (subsetToOthers) {
+          // We can convert from subset to other.  So, add converter with subset as child and
+          // traitset as the other's traitset.
+          canConvert = traitDef.canConvert(
+                  cluster.getPlanner(), curRelTrait, curOtherTrait, subset);
+          needConvert = !curRelTrait.satisfies(curOtherTrait);
+        } else {
+          // We can convert from others to subset.
+          canConvert = traitDef.canConvert(
+                  cluster.getPlanner(), curOtherTrait, curRelTrait, other);
+          needConvert = !curOtherTrait.satisfies(curRelTrait);
+        }
+
+        if (!canConvert) {
+          addAbstractConverter = false;
+          break;
+        }
+
+        if (needConvert) {
+          numTraitNeedConvert++;
+        }
+      }
+
+      if (addAbstractConverter && numTraitNeedConvert > 0) {
+        if (subsetToOthers) {
+          final AbstractConverter converter =
+                  new AbstractConverter(cluster, subset, null, other.getTraitSet());
+          planner.register(converter, other);
+        } else {
+          final AbstractConverter converter =
+                  new AbstractConverter(cluster, other, null, subset.getTraitSet());
+          planner.register(converter, subset);
+        }
+      }
+    }
+  }
+
   RelSubset getOrCreateSubset(
       RelOptCluster cluster,
       RelTraitSet traits) {
@@ -159,40 +225,13 @@ class RelSet {
       final VolcanoPlanner planner =
           (VolcanoPlanner) cluster.getPlanner();
 
-      // Converters from newly introduced subset to all the remaining one (vice versa), only if
-      // we can convert.  No point adding converters if it is not possible.
-      for (RelSubset other : subsets) {
-        if (other == subset) {
-          continue;
-        }
+      addAbstractConverters(planner, cluster, subset, true);
 
-        assert other.getTraitSet().size() == subset.getTraitSet().size();
+      // Need to first add to subset before adding the abstract converters (for others->subset)
+      // since otherwise during register() the planner will try to add this subset again.
+      subsets.add(subset);
 
-        final ImmutableList<RelTrait> thisTrait =
-                other.getTraitSet().difference(subset.getTraitSet());
-        final ImmutableList<RelTrait> otherTrait =
-                subset.getTraitSet().difference(other.getTraitSet());
-        assert thisTrait.size() == otherTrait.size();
-
-        if (thisTrait.size() == 1 && otherTrait.size() == 1) {
-
-          assert thisTrait.get(0).getTraitDef() == otherTrait.get(0).getTraitDef();
-
-          RelTraitDef traitDef = otherTrait.get(0).getTraitDef();
-
-          // We can convert from subset to other.  So, add converter with subset as child and
-          // traitset as the other's traitset.
-          boolean canConvert = traitDef.canConvert(
-                  cluster.getPlanner(), thisTrait.get(0), otherTrait.get(0), subset);
-          boolean needConvert = !thisTrait.get(0).satisfies(otherTrait.get(0));
-
-          if (canConvert && needConvert) {
-            final AbstractConverter converter =
-                    new AbstractConverter(cluster, subset, traitDef, other.getTraitSet());
-            planner.register(converter, other);
-          }
-        }
-      }
+      addAbstractConverters(planner, cluster, subset, false);
 
       // Need to first add to subset before adding the abstract converters (for others->subset)
       // since otherwise during register() the planner will try to add this subset again.

--- a/core/src/main/java/org/apache/calcite/rel/RelCollationTraitDef.java
+++ b/core/src/main/java/org/apache/calcite/rel/RelCollationTraitDef.java
@@ -81,16 +81,13 @@ public class RelCollationTraitDef extends RelTraitDef<RelCollation> {
     return newRel;
   }
 
-  public boolean canConvert(RelOptPlanner planner,
-                            RelCollation fromTrait,
-                            RelCollation toTrait) {
+  public boolean canConvert(
+       RelOptPlanner planner, RelCollation fromTrait, RelCollation toTrait) {
     return false;
   }
 
-  @Override public boolean canConvert(RelOptPlanner planner,
-                                      RelCollation fromTrait,
-                                      RelCollation toTrait,
-                                      RelNode fromRel) {
+  @Override public boolean canConvert(
+       RelOptPlanner planner, RelCollation fromTrait, RelCollation toTrait, RelNode fromRel) {
     // Should return true only if we can convert.  In this case, we can only convert if the
     // fromTrait (the child/input) has fields that the toTrait wants to sort.
     for (RelFieldCollation field : toTrait.getFieldCollations()) {

--- a/core/src/test/java/org/apache/calcite/plan/volcano/CollationConversionTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/CollationConversionTest.java
@@ -47,7 +47,9 @@ import java.util.List;
 import static org.apache.calcite.plan.volcano.VolcanoPlannerTest.PHYS_CALLING_CONVENTION;
 import static org.apache.calcite.plan.volcano.VolcanoPlannerTest.newCluster;
 
-/** */
+/**
+ * Unit test for {@link org.apache.calcite.rel.RelCollationTraitDef}.
+ */
 public class CollationConversionTest {
 
   public TestRelCollationImpl leafCollation =
@@ -80,18 +82,18 @@ public class CollationConversionTest {
     RelNode result = planner.chooseDelegate().findBestExp();
   }
 
-  /** Converts a NoneSingleRel -> RootSingleRel */
+  /**
+   * Converts a NoneSingleRel to RootSingleRel
+   */
   class SingleNodeRule extends RelOptRule {
     SingleNodeRule() {
       super(operand(NoneSingleRel.class, any()));
     }
 
-    // implement RelOptRule
     public Convention getOutConvention() {
       return PHYS_CALLING_CONVENTION;
     }
 
-    // implement RelOptRule
     public void onMatch(RelOptRuleCall call) {
       NoneSingleRel singleRel = call.rel(0);
       RelNode childRel = singleRel.getInput();
@@ -107,7 +109,9 @@ public class CollationConversionTest {
     }
   }
 
-  /** RootSingleRel */
+  /**
+   * RootSingleRel: Root node with physical convention and rootCollation trait.
+   */
   class RootSingleRel extends TestSingleRel {
     RootSingleRel(
             RelOptCluster cluster,
@@ -118,7 +122,6 @@ public class CollationConversionTest {
               child);
     }
 
-    // implement RelNode
     public RelOptCost computeSelfCost(
             RelOptPlanner planner,
             RelMetadataQuery mq) {
@@ -131,18 +134,18 @@ public class CollationConversionTest {
     }
   }
 
-  /** Converts NoneLeafRel -> LeafRel  */
+  /**
+   * Converts a NoneLeafRel (with none convention) to LeafRel (with physical convention)
+   */
   class LeafTraitRule extends RelOptRule {
     LeafTraitRule() {
       super(operand(NoneLeafRel.class, any()));
     }
 
-    // implement RelOptRule
     public Convention getOutConvention() {
       return PHYS_CALLING_CONVENTION;
     }
 
-    // implement RelOptRule
     public void onMatch(RelOptRuleCall call) {
       NoneLeafRel leafRel = call.rel(0);
       call.transformTo(
@@ -150,7 +153,9 @@ public class CollationConversionTest {
     }
   }
 
-  /** SingletonLeafRel */
+  /**
+   * SingletonLeafRel:  leaf node with physical convention and leafCollation trait
+   */
   class LeafRel extends TestLeafRel {
     LeafRel(
             RelOptCluster cluster,
@@ -159,7 +164,6 @@ public class CollationConversionTest {
               .plus(leafCollation), label);
     }
 
-    // implement RelNode
     public RelOptCost computeSelfCost(RelOptPlanner planner,
                                       RelMetadataQuery mq) {
       return planner.getCostFactory().makeTinyCost();
@@ -170,7 +174,9 @@ public class CollationConversionTest {
     }
   }
 
-  /** NoneLeafRel (has simple distribution of ANY) */
+  /**
+   * NoneLeafRel:  leaf node with none convention and leafCollation trait
+   */
   class NoneLeafRel extends TestLeafRel {
     protected NoneLeafRel(
             RelOptCluster cluster,
@@ -188,7 +194,9 @@ public class CollationConversionTest {
     }
   }
 
-  /** NoneSingleRel (has simple distribution of ANY) */
+  /**
+   * NoneSingleRel:  a single relNode with none convention and leafCollation trait
+   */
   class NoneSingleRel extends TestSingleRel {
     protected NoneSingleRel(
             RelOptCluster cluster,
@@ -207,7 +215,9 @@ public class CollationConversionTest {
     }
   }
 
-  /** */
+  /**
+   * Dummy collation trait implementation for the test
+   */
   public class TestRelCollationImpl extends RelCollationImpl {
 
     public TestRelCollationImpl(ImmutableList<RelFieldCollation> fieldCollations) {
@@ -219,7 +229,9 @@ public class CollationConversionTest {
     }
   }
 
-  /** */
+  /**
+   * Dummy collation trait def implementation for the test (uses the PhysicalSort below)
+   */
   public class TestRelCollationTraitDef extends RelTraitDef<RelCollation> {
     public Class<RelCollation> getTraitClass() {
       return RelCollation.class;
@@ -258,7 +270,9 @@ public class CollationConversionTest {
     }
   }
 
-  /** Physical Sort RelNode */
+  /**
+   * Physical Sort RelNode (not logical)
+   */
   public class PhysicalSort extends Sort {
     public PhysicalSort(RelOptCluster cluster, RelTraitSet traits, RelNode child,
                     RelCollation collation, RexNode offset,

--- a/core/src/test/java/org/apache/calcite/plan/volcano/ComboRuleTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/ComboRuleTest.java
@@ -44,11 +44,10 @@ import static org.apache.calcite.plan.volcano.VolcanoPlannerTest.newCluster;
 
 import static org.junit.Assert.assertTrue;
 
-
-/** Tests a combo rule that propagates an IntermediateNode up to the root from the leaf */
+/**
+ * Unit test for {@link VolcanoPlanner}
+ */
 public class ComboRuleTest {
-
-  /** test */
   @Test
   public void testCombo() {
     VolcanoPlanner planner = new VolcanoPlanner();
@@ -80,7 +79,10 @@ public class ComboRuleTest {
     assertTrue(result instanceof IntermediateNode);
   }
 
-  /** Intermediate node, the cost decreases as it is pushed up the tree */
+  /**
+   * Intermediate node, the cost decreases as it is pushed up the tree
+   * (more children it has, cheaper it gets)
+   */
   private static class IntermediateNode extends TestSingleRel {
 
     private final int numNodesBelow;
@@ -92,7 +94,6 @@ public class ComboRuleTest {
 
     public int getNumNodesBelow() { return numNodesBelow; }
 
-    // implement RelNode
     public RelOptCost computeSelfCost(RelOptPlanner planner,
                                       RelMetadataQuery mq) {
       return planner.getCostFactory().makeCost(100, 100, 100).multiplyBy(1.0 / numNodesBelow);
@@ -104,18 +105,18 @@ public class ComboRuleTest {
     }
   }
 
-  /** Adds an intermediate node above the PhysLeafRel */
+  /**
+   * Rule that adds an intermediate node above the PhysLeafRel
+   */
   private static class AddIntermediateNodeRule extends RelOptRule {
     AddIntermediateNodeRule() {
       super(operand(NoneLeafRel.class, any()));
     }
 
-    // implement RelOptRule
     public Convention getOutConvention() {
       return PHYS_CALLING_CONVENTION;
     }
 
-    // implement RelOptRule
     public void onMatch(RelOptRuleCall call) {
       NoneLeafRel leaf = call.rel(0);
 
@@ -126,7 +127,9 @@ public class ComboRuleTest {
     }
   }
 
-  /** Matches PhysSingleRel-IntermediateNode-Any and converts to Intermediate-PhysSingleRel-Any */
+  /**
+   * Matches PhysSingleRel-IntermediateNode-Any and converts to Intermediate-PhysSingleRel-Any
+   */
   private static class ComboRule extends RelOptRule {
     ComboRule() {
       super(createOperand());
@@ -139,7 +142,6 @@ public class ComboRuleTest {
       return input;
     }
 
-    // implement RelOptRule
     public Convention getOutConvention() {
       return PHYS_CALLING_CONVENTION;
     }

--- a/core/src/test/java/org/apache/calcite/plan/volcano/TraitConversionTest.java
+++ b/core/src/test/java/org/apache/calcite/plan/volcano/TraitConversionTest.java
@@ -40,7 +40,9 @@ import java.util.List;
 import static org.apache.calcite.plan.volcano.VolcanoPlannerTest.PHYS_CALLING_CONVENTION;
 import static org.apache.calcite.plan.volcano.VolcanoPlannerTest.newCluster;
 
-/** Test for converting rel distribution */
+/**
+ * Unit test for {@link org.apache.calcite.rel.RelDistributionTraitDef}.
+ */
 public class TraitConversionTest {
 
   final ConvertRelDistributionTraitDef newTraitDefInstance = new ConvertRelDistributionTraitDef();
@@ -70,18 +72,19 @@ public class TraitConversionTest {
     RelNode result = planner.chooseDelegate().findBestExp();
   }
 
-  /** Converts a NoneSingleRel -> RandomSingleRel */
+  /**
+   * Converts a NoneSingleRel (none convention, distribution any) to RandomSingleRel
+   * (physical convention, distribution random)
+   */
   class RandomSingleTraitRule extends RelOptRule {
     RandomSingleTraitRule() {
       super(operand(NoneSingleRel.class, any()));
     }
 
-    // implement RelOptRule
     public Convention getOutConvention() {
       return PHYS_CALLING_CONVENTION;
     }
 
-    // implement RelOptRule
     public void onMatch(RelOptRuleCall call) {
       NoneSingleRel singleRel = call.rel(0);
       RelNode childRel = singleRel.getInput();
@@ -97,7 +100,9 @@ public class TraitConversionTest {
     }
   }
 
-  /** RandomSingleRel */
+  /**
+   * RandomSingleRel:  Rel with physical convention and random distribution
+   */
   class RandomSingleRel extends TestSingleRel {
     RandomSingleRel(
             RelOptCluster cluster,
@@ -108,7 +113,6 @@ public class TraitConversionTest {
          child);
     }
 
-    // implement RelNode
     public RelOptCost computeSelfCost(
             RelOptPlanner planner,
             RelMetadataQuery mq) {
@@ -121,18 +125,19 @@ public class TraitConversionTest {
     }
   }
 
-  /** Converts NoneLeafRel -> SingletonLeafRel  */
+  /**
+   * Converts NoneLeafRel (none convention, any distribution) to SingletonLeafRel
+   * (physical convention, singleton distribution)
+   */
   class SingleLeafTraitRule extends RelOptRule {
     SingleLeafTraitRule() {
       super(operand(NoneLeafRel.class, any()));
     }
 
-    // implement RelOptRule
     public Convention getOutConvention() {
       return PHYS_CALLING_CONVENTION;
     }
 
-    // implement RelOptRule
     public void onMatch(RelOptRuleCall call) {
       NoneLeafRel leafRel = call.rel(0);
       call.transformTo(
@@ -140,7 +145,9 @@ public class TraitConversionTest {
     }
   }
 
-  /** SingletonLeafRel */
+  /**
+   * SingletonLeafRel (with singleton distribution, physical convention)
+   */
   class SingletonLeafRel extends TestLeafRel {
     SingletonLeafRel(
             RelOptCluster cluster,
@@ -149,7 +156,6 @@ public class TraitConversionTest {
               .plus(simpleDistributionSingleton), label);
     }
 
-    // implement RelNode
     public RelOptCost computeSelfCost(RelOptPlanner planner,
                                       RelMetadataQuery mq) {
       return planner.getCostFactory().makeTinyCost();
@@ -160,7 +166,9 @@ public class TraitConversionTest {
     }
   }
 
-  /** Bridges the SimpleDistribution difference between SingletonLeafRel and RandomSingleRel */
+  /**
+   * Bridges the SimpleDistribution, difference between SingletonLeafRel and RandomSingleRel
+   */
   class BridgeRel extends TestSingleRel {
     BridgeRel(
             RelOptCluster cluster,
@@ -169,7 +177,6 @@ public class TraitConversionTest {
               .plus(simpleDistributionRandom), child);
     }
 
-    // implement RelNode
     public RelOptCost computeSelfCost(RelOptPlanner planner,
                                       RelMetadataQuery mq) {
       return planner.getCostFactory().makeTinyCost();
@@ -180,7 +187,9 @@ public class TraitConversionTest {
     }
   }
 
-  /** Distribution (simplified version of RelDistribution) */
+  /**
+   * Dummy distribution for test (simplified version of RelDistribution)
+   */
   public class SimpleDistribution implements RelTrait {
 
     private final String name;
@@ -212,7 +221,9 @@ public class TraitConversionTest {
     @Override public void register(RelOptPlanner planner) {}
   }
 
-  /** Handles conversion of SimpleDistribution */
+  /**
+   * Dummy distribution trait def for test (handles conversion of SimpleDistribution)
+   */
   public class ConvertRelDistributionTraitDef extends RelTraitDef<SimpleDistribution> {
 
     private ConvertRelDistributionTraitDef() {}
@@ -259,8 +270,9 @@ public class TraitConversionTest {
     }
   }
 
-
-  /** NoneLeafRel (has simple distribution of ANY) */
+  /**
+   * NoneLeafRel (any distribution and none convention)
+   */
   class NoneLeafRel extends TestLeafRel {
     protected NoneLeafRel(
             RelOptCluster cluster,
@@ -278,7 +290,9 @@ public class TraitConversionTest {
     }
   }
 
-  /** NoneSingleRel (has simple distribution of ANY) */
+  /**
+   * NoneSingleRel (any distribution and none convention)
+   */
   class NoneSingleRel extends TestSingleRel {
     protected NoneSingleRel(
             RelOptCluster cluster,
@@ -296,6 +310,5 @@ public class TraitConversionTest {
               sole(inputs));
     }
   }
-
 }
 // End TraitConversionTest.java

--- a/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
+++ b/core/src/test/java/org/apache/calcite/test/CalciteSuite.java
@@ -21,6 +21,8 @@ import org.apache.calcite.jdbc.CalciteRemoteDriverTest;
 import org.apache.calcite.plan.RelOptPlanReaderTest;
 import org.apache.calcite.plan.RelOptUtilTest;
 import org.apache.calcite.plan.RelWriterTest;
+import org.apache.calcite.plan.volcano.CollationConversionTest;
+import org.apache.calcite.plan.volcano.TraitConversionTest;
 import org.apache.calcite.plan.volcano.TraitPropagationTest;
 import org.apache.calcite.plan.volcano.VolcanoPlannerTest;
 import org.apache.calcite.plan.volcano.VolcanoPlannerTraitTest;
@@ -92,6 +94,8 @@ import org.junit.runners.Suite;
     ExceptionMessageTest.class,
     InduceGroupingTypeTest.class,
     RelOptPlanReaderTest.class,
+    CollationConversionTest.class,
+    TraitConversionTest.class,
 
     // medium tests (above 0.1s)
     SqlParserTest.class,

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -1332,13 +1332,14 @@ public class JdbcTest {
             + "and p.\"brand_name\" = 'Washington'")
         .explainMatches("including all attributes ",
             CalciteAssert.checkMaskedResultContains(""
-                + "EnumerableJoin(condition=[=($0, $38)], joinType=[inner]): rowcount = 7.050660528307499E8, cumulative cost = {1.0640240216183146E9 rows, 777302.0 cpu, 0.0 io}\n"
-                + "  EnumerableJoin(condition=[=($2, $8)], joinType=[inner]): rowcount = 2.0087351932499997E7, cumulative cost = {2.117504719375143E7 rows, 724261.0 cpu, 0.0 io}\n"
-                + "    EnumerableTableScan(table=[[foodmart2, sales_fact_1997]]): rowcount = 86837.0, cumulative cost = {86837.0 rows, 86838.0 cpu, 0.0 io}\n"
-                + "    EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco'], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30]): rowcount = 1542.1499999999999, cumulative cost = {11823.15 rows, 637423.0 cpu, 0.0 io}\n"
-                + "      EnumerableTableScan(table=[[foodmart2, customer]]): rowcount = 10281.0, cumulative cost = {10281.0 rows, 10282.0 cpu, 0.0 io}\n"
+                + "EnumerableMergeJoin(condition=[=($0, $38)], joinType=[inner]): rowcount = 7.050660528307499E8, cumulative cost = {7.655269545978069E8 rows, 1.4872413450049999E9 cpu, 0.0 io}\n"
+                + "  EnumerableCalc(expr#0..36=[{inputs}], product_id=[$t29], time_id=[$t30], customer_id=[$t31], promotion_id=[$t32], store_id=[$t33], store_sales=[$t34], store_cost=[$t35], unit_sales=[$t36], customer_id0=[$t0], account_num=[$t1], lname=[$t2], fname=[$t3], mi=[$t4], address1=[$t5], address2=[$t6], address3=[$t7], address4=[$t8], city=[$t9], state_province=[$t10], postal_code=[$t11], country=[$t12], customer_region_id=[$t13], phone1=[$t14], phone2=[$t15], birthdate=[$t16], marital_status=[$t17], yearly_income=[$t18], gender=[$t19], total_children=[$t20], num_children_at_home=[$t21], education=[$t22], date_accnt_opened=[$t23], member_card=[$t24], occupation=[$t25], houseowner=[$t26], num_cars_owned=[$t27], fullname=[$t28]): rowcount = 2.0087351932499997E7, cumulative cost = {4.037152183455708E7 rows, 1.4871883040049999E9 cpu, 0.0 io}\n"
+                + "    EnumerableJoin(condition=[=($0, $31)], joinType=[inner]): rowcount = 2.0087351932499997E7, cumulative cost = {2.028416990205708E7 rows, 724261.0 cpu, 0.0 io}\n"
+                + "      EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco'], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30]): rowcount = 1542.1499999999999, cumulative cost = {11823.15 rows, 637423.0 cpu, 0.0 io}\n"
+                + "        EnumerableTableScan(table=[[foodmart2, customer]]): rowcount = 10281.0, cumulative cost = {10281.0 rows, 10282.0 cpu, 0.0 io}\n"
+                + "      EnumerableTableScan(table=[[foodmart2, sales_fact_1997]]): rowcount = 86837.0, cumulative cost = {86837.0 rows, 86838.0 cpu, 0.0 io}\n"
                 + "  EnumerableCalc(expr#0..14=[{inputs}], expr#15=['Washington'], expr#16=[=($t2, $t15)], proj#0..14=[{exprs}], $condition=[$t16]): rowcount = 234.0, cumulative cost = {1794.0 rows, 53041.0 cpu, 0.0 io}\n"
-                + "    EnumerableTableScan(table=[[foodmart2, product]]): rowcount = 1560.0, cumulative cost = {1560.0 rows, 1561.0 cpu, 0.0 io}\n"));
+                + "    EnumerableTableScan(table=[[foodmart2, product]]): rowcount = 1560.0, cumulative cost = {1560.0 rows, 1561.0 cpu, 0.0 io}"));
   }
 
   /** Tests a query whose best plan is a bushy join.
@@ -1934,6 +1935,7 @@ public class JdbcTest {
     //   12    36
     //   13   116 - OOM did not complete
     checkJoinNWay(1);
+    checkJoinNWay(3);
     checkJoinNWay(6);
   }
 

--- a/core/src/test/resources/sql/misc.iq
+++ b/core/src/test/resources/sql/misc.iq
@@ -569,11 +569,12 @@ from "sales_fact_1997" as s
   join "customer" as c using ("customer_id")
   join "product" as p using ("product_id")
 where c."city" = 'San Francisco';
-EnumerableJoin(condition=[=($0, $38)], joinType=[inner])
-  EnumerableJoin(condition=[=($2, $8)], joinType=[inner])
-    EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])
-    EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco'], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30])
-      EnumerableTableScan(table=[[foodmart2, customer]])
+EnumerableMergeJoin(condition=[=($0, $38)], joinType=[inner])
+  EnumerableCalc(expr#0..36=[{inputs}], product_id=[$t29], time_id=[$t30], customer_id=[$t31], promotion_id=[$t32], store_id=[$t33], store_sales=[$t34], store_cost=[$t35], unit_sales=[$t36], customer_id0=[$t0], account_num=[$t1], lname=[$t2], fname=[$t3], mi=[$t4], address1=[$t5], address2=[$t6], address3=[$t7], address4=[$t8], city=[$t9], state_province=[$t10], postal_code=[$t11], country=[$t12], customer_region_id=[$t13], phone1=[$t14], phone2=[$t15], birthdate=[$t16], marital_status=[$t17], yearly_income=[$t18], gender=[$t19], total_children=[$t20], num_children_at_home=[$t21], education=[$t22], date_accnt_opened=[$t23], member_card=[$t24], occupation=[$t25], houseowner=[$t26], num_cars_owned=[$t27], fullname=[$t28])
+    EnumerableJoin(condition=[=($0, $31)], joinType=[inner])
+      EnumerableCalc(expr#0..28=[{inputs}], expr#29=['San Francisco'], expr#30=[=($t9, $t29)], proj#0..28=[{exprs}], $condition=[$t30])
+        EnumerableTableScan(table=[[foodmart2, customer]])
+      EnumerableTableScan(table=[[foodmart2, sales_fact_1997]])
   EnumerableTableScan(table=[[foodmart2, product]])
 !plan
 


### PR DESCRIPTION
…ses.
- Address review comments:  comments, javadoc, etc.
- Address review comments:  combine two for-loops into one, use RelTraitDef.satisfies()
- Fix RelCollationTraitDef.canConvert() to return true only if it actually can convert
- Create AbstractConverters with correct child in RelSet, introduce canConvert with RelNode to handle RelCollationTraits properly
- Add abstract converters via helper function
